### PR TITLE
Fix variable scope issues in navigation scripts

### DIFF
--- a/assets/js/hamburger.js
+++ b/assets/js/hamburger.js
@@ -84,7 +84,7 @@ hamburgerListbox.addEventListener('keydown', function(event) {
 
 // Used with arrow key and tab navigation to move focus/selection to next item
 function moveToNextHamburgerItem() {
-  idx = nextHamburgerIdx();
+  let idx = nextHamburgerIdx();
   removeAllHamburgerBG();
   hamburgerMenuItems[idx].classList.add(hamburgerBGActive, hamburgerBGActiveDark);
   hamburgerActiveItem = hamburgerMenuItems[idx];
@@ -93,7 +93,7 @@ function moveToNextHamburgerItem() {
 
 // Used with arrow key and tab navigation to move focus/selection to previous item
 function moveToPrevHamburgerItem() {
-  idx = prevHamburgerIdx();
+  let idx = prevHamburgerIdx();
   removeAllHamburgerBG();
   hamburgerMenuItems[idx].classList.add(hamburgerBGActive, hamburgerBGActiveDark);
   hamburgerActiveItem = hamburgerMenuItems[idx];

--- a/assets/js/theme-switch.js
+++ b/assets/js/theme-switch.js
@@ -222,7 +222,7 @@ themeswitchListbox.addEventListener('keydown', function(event) {
 
 // Used with arrow key and tab navigation to move selection to next option
 function moveToNextThemeswitchOption() {
-  movedToOption = nextOption();
+  let movedToOption = nextOption();
   removeAllBG();
   movedToOption.classList.add(themeswitchBGActive, themeswitchBGActiveDark);
   themeswitchActiveOption = movedToOption;
@@ -230,7 +230,7 @@ function moveToNextThemeswitchOption() {
 
 // Used with arrow key and tab navigation to move selection to previous option
 function moveToPrevThemeswitchOption() {
-  movedToOption = prevOption();
+  let movedToOption = prevOption();
   removeAllBG();
   movedToOption.classList.add(themeswitchBGActive, themeswitchBGActiveDark);
   themeswitchActiveOption = movedToOption;

--- a/layouts/partials/hamburger.html
+++ b/layouts/partials/hamburger.html
@@ -1,4 +1,4 @@
-<!-- Mobile hamburget menu -->
+<!-- Mobile hamburger menu -->
 <!-- Only works with corresponding Javascript loaded. -->
 
 <!-- Used to highlight current page in navbar -->


### PR DESCRIPTION
## Summary
- declare local variables in hamburger and theme-switch scripts to avoid globals
- fix typo in hamburger menu comment

## Testing
- `npm run compile-tailwind` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843437f056883339c3a155a4f19eaf9