### PR TITLE
Fix minor typo in vimtex tutorial

### DIFF
--- a/content/tutorials/vim-latex/vimtex/index.md
+++ b/content/tutorials/vim-latex/vimtex/index.md
@@ -464,7 +464,7 @@ You can:
 
   {{< img-centered src="move-frame.gif" width="100%" alt="GIF: demonstrating navigation between Beamer frames." >}}
 
-<!-- **TODO:** I did not get this motion ot work in testing! -->
+<!-- **TODO:** I did not get this motion to work in testing! -->
 <!-- - Jump to the beginning of the next or previous LaTeX comment (i.e. text beginning with `%`) -->
 <!--   using `]/` and `<Plug>(vimtex-]/`, and `[/` `<Plug>(vimtex-]star`). -->
 


### PR DESCRIPTION
## Summary
- fix a typo in a comment in the VimTeX tutorial

## Testing
- `npm run compile-tailwind` *(fails: 403 Forbidden on npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6843456e868883338492eaf9ea998f3e