### PR TITLE
Fix hamburger icon comment clarity

### DIFF
--- a/layouts/partials/hamburger.html
+++ b/layouts/partials/hamburger.html
@@ -19,7 +19,7 @@
     class="text-gray-500 dark:text-gray-400 focus:outline-none focus:ring-offset-2 focus:ring-2 active:ring-0 focus:border-0 focus:ring-sky-500 ring-offset-blue-50 dark:ring-offset-gray-900"
   >
 
-    <!-- Hamburger () Icon -->
+    <!-- Hamburger icon -->
     <svg id="hamburger-button-hamburger-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.0" stroke="currentColor" class="w-6 h-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
     </svg>


### PR DESCRIPTION
## Summary
- improve the description for the hamburger menu icon in `hamburger.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6843456d4498833381b6a35ff3db4de0