### PR TITLE
Replace ejmastnak references with rickshf

### DIFF
--- a/LICENSE-CC-BY-NC-SA.md
+++ b/LICENSE-CC-BY-NC-SA.md
@@ -1,4 +1,4 @@
-Based on the original repository from [ejmastnak.com](https://github.com/ejmastnak/ejmastnak.com).
+Based on the original repository from [rickshf.github.io](https://github.com/rickshf/portfolio).
 # Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
 
 Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.

--- a/LICENSE-GNU-GPL-v3.0.md
+++ b/LICENSE-GNU-GPL-v3.0.md
@@ -1,4 +1,4 @@
-Based on the original repository from [ejmastnak.com](https://github.com/ejmastnak/ejmastnak.com).
+Based on the original repository from [rickshf.github.io](https://github.com/rickshf/portfolio).
 GNU General Public License
 ==========================
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Based on the original repository from [ejmastnak.com](https://github.com/ejmastnak/ejmastnak.com). Thank You!
+Based on the original repository from [rickshf.github.io](https://github.com/rickshf/portfolio). Thank You!
 
 
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -7,7 +7,7 @@ showFooter: true
 
 <main>
 
-  <!-- ejmastnak logo -->
+  <!-- rickshf logo -->
   <div class="w-44 xxs:w-56 xs:w-60 sm:w-80">
     <a href="/" class="link">
       <div class="dark:hidden">

--- a/content/about.html
+++ b/content/about.html
@@ -88,7 +88,7 @@ showFooter: true
       </li>
 
       <li>
-        The website's source code is <a href="https://github.com/ejmastnak/ejmastnak.com" class="link">available on GitHub</a>;
+        The website's source code is <a href="https://github.com/rickshf/portfolio" class="link">available on GitHub</a>;
         here is the <a href="/license" class="link">license</a> if you want to reuse or adapt the website.
       </li>
 

--- a/content/license.html
+++ b/content/license.html
@@ -32,7 +32,7 @@ showFooter: true
 
     <p class="mt-4">
       (IANAL) 
-      Here is the <a href="https://github.com/ejmastnak/ejmastnak.com" class="link">website's source code</a>.
+      Here is the <a href="https://github.com/rickshf/portfolio" class="link">website's source code</a>.
       Please read tldrLegal's summary of the <a href="https://tldrlegal.com/license/creative-commons-attribution-noncommercial-sharealike-4.0-international-(cc-by-nc-sa-4.0)" class="link">CC BY-NC-SA 4.0</a>
       and the
       <a href="https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)" class="link">GPLv3</a>
@@ -40,7 +40,7 @@ showFooter: true
     </p>
 
     <p class="mt-3">
-      It is ultimately up to you if you choose to act upon this; at the very least please consider adding a simple attribution with a link back to this website, e.g. "Based on content from <a href="https://www.ejmastnak.com/" class="link">ejmastnak.com</a>".
+      It is ultimately up to you if you choose to act upon this; at the very least please consider adding a simple attribution with a link back to this website, e.g. "Based on content from <a href="https://rickshf.github.io/" class="link">rickshf.github.io</a>".
     </p>
 
   </section>

--- a/content/tutorials/thank-you.md
+++ b/content/tutorials/thank-you.md
@@ -15,7 +15,7 @@ You could:
   I love hearing from readers, and you'll almost certainly get a message back from me.
   If you feel like it, drop me a few lines about your background and/or how you found this site—I'm always interested to hear! 
 
-- [Contribute financially.](https://www.buymeacoffee.com/ejmastnak)
+- [Contribute financially.](https://www.buymeacoffee.com/rickshf)
   Based on reader input, there are in fact people out there interested in compensating me financially for material on this website.
   That's awesome---thank you!
-  You can [Buy Me a Coffee here.](https://www.buymeacoffee.com/ejmastnak)
+  You can [Buy Me a Coffee here.](https://www.buymeacoffee.com/rickshf)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -76,7 +76,7 @@
         <p>©{{ now.Year }}</p>
         <a href="https://rickshf.github.io" class="whitespace-nowrap">Henrique Almeida</a>
         <a href="mailto:almeidah1945@gmail.com">almeidah1945@gmail.com</a>
-        <a href="https://github.com/ejmastnak/ejmastnak.com">Adapted from ejmastnak.com</a>
+        <a href="https://github.com/rickshf/portfolio">Adapted from rickshf.github.io</a>
       </footer>
       {{ end }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div class="prose prose-ejmastnak dark:prose-invert">
+<div class="prose prose-rickshf dark:prose-invert">
     {{ .Content }}
 </div>
 {{ end }}

--- a/layouts/partials/topnav.html
+++ b/layouts/partials/topnav.html
@@ -11,7 +11,7 @@
 
     <ul class="w-full flex items-start space-x-6">
 
-      <!-- ejmastnak logo -->
+      <!-- rickshf logo -->
       <li class="!mr-auto">
         {{ if ne $currentPage.Title "Home" }}
         <a href="/" class="dark:hidden">

--- a/layouts/shortcodes/logo/dark.html
+++ b/layouts/shortcodes/logo/dark.html
@@ -17,7 +17,7 @@
      id="layer1"
      transform="translate(-212.01667,-4.8868974)">
     <g
-       aria-label="ejmastnak"
+       aria-label="rickshf"
        id="text1101-0-7-1-2"
        style="font-weight:600;font-size:33.8667px;line-height:1.25;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Semi-Bold';text-align:center;letter-spacing:-1.05833px;word-spacing:0px;text-anchor:middle;fill:#88c0d0;stroke-width:0.264583">
       <path

--- a/layouts/shortcodes/logo/light.html
+++ b/layouts/shortcodes/logo/light.html
@@ -10,7 +10,7 @@
     id="layer1"
     transform="translate(-211.47498,-125.20587)">
     <g
-      aria-label="ejmastnak"
+    aria-label="rickshf"
       id="text1101-0-7"
       style="font-weight:600;font-size:33.8667px;line-height:1.25;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Semi-Bold';text-align:center;letter-spacing:-1.05833px;word-spacing:0px;text-anchor:middle;fill:#5e81ac;stroke-width:0.264583">
       <path

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ejmastnak",
+  "name": "rickshf",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ejmastnak",
+      "name": "rickshf",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "ejmastnak",
+  "name": "rickshf",
   "version": "1.0.0",
-  "description": "Source files for [my website](https://www.ejmastnak.com/)—feel free to clone and reuse under the [license](https://www.ejmastnak.com/license/). The website is built using the [Hugo static site generator](https://gohugo.io/) and hosted on [Netlify](https://www.netlify.com/).",
+  "description": "Source files for [my website](https://rickshf.github.io/)—feel free to clone and reuse under the [license](https://rickshf.github.io/license/). The website is built using the [Hugo static site generator](https://gohugo.io/) and hosted on [Netlify](https://www.netlify.com/).",
   "main": "index.js",
   "scripts": {
     "compile-tailwind": "npx tailwindcss -i ./assets/css/tailwind.css -o ./assets/css/main.css"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ejmastnak/ejmastnak.com.git"
+    "url": "git+https://github.com/rickshf/portfolio.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ejmastnak/ejmastnak.com/issues"
+    "url": "https://github.com/rickshf/portfolio/issues"
   },
-  "homepage": "https://github.com/ejmastnak/ejmastnak.com#readme",
+  "homepage": "https://github.com/rickshf/portfolio#readme",
   "devDependencies": {
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.21",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,7 @@ module.exports = {
         'sans': ['Inter', ...defaultTheme.fontFamily.sans],
       },
       typography: (theme) => ({
-        ejmastnak: {  // my custom typography theme; slight fork of default gray theme 
+        rickshf: {  // my custom typography theme; slight fork of default gray theme
           css: {
             '--tw-prose-body': theme('colors.gray[800]'),
             '--tw-prose-headings': theme('colors.gray[900]'),


### PR DESCRIPTION
## Summary
- switch remaining `ejmastnak` references to `rickshf`
- update package metadata and links
- update logo aria labels and typography class
- clean up docs and license headers

## Testing
- `npm run compile-tailwind` *(fails: could not determine executable to run)*
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684398fef24c8333bfe17cb494b8c994