### PR TITLE
Add language dropdown switcher

### DIFF
--- a/assets/js/lang-switch.js
+++ b/assets/js/lang-switch.js
@@ -1,0 +1,143 @@
+var langswitchContainer = document.getElementById('langswitch-container');
+langswitchContainer.classList.remove('hidden');
+
+var langswitchListbox = document.getElementById('langswitch-options');
+var langswitchButton = document.getElementById('langswitch-button');
+var langswitchCurrent = document.getElementById('langswitch-current');
+var langswitchEnOption = document.getElementById('langswitch-en-option');
+var langswitchPtOption = document.getElementById('langswitch-pt-option');
+var langswitchOptions = [langswitchEnOption, langswitchPtOption];
+var langswitchActiveOption = langswitchEnOption;
+
+const langswitchBGActive = 'bg-gray-100';
+const langswitchBGActiveDark = 'dark:bg-gray-700';
+
+function hideLangbox() {
+  langswitchButton.setAttribute('aria-expanded','false');
+  langswitchListbox.classList.add('hidden');
+  langswitchListbox.blur();
+}
+
+function showLangbox() {
+  langswitchButton.setAttribute('aria-expanded','true');
+  langswitchOptions.forEach(option => {
+    if(option.getAttribute('aria-selected') === 'true') {
+      option.classList.add(langswitchBGActive, langswitchBGActiveDark);
+    }
+  });
+  langswitchListbox.classList.remove('hidden');
+  langswitchListbox.focus();
+}
+
+function toggleLangbox() {
+  const expanded = langswitchButton.getAttribute('aria-expanded');
+  expanded === 'true' ? hideLangbox() : showLangbox();
+}
+
+function removeAllBG() {
+  langswitchOptions.forEach(o => o.classList.remove(langswitchBGActive, langswitchBGActiveDark));
+}
+
+function switchSelectedAttributeTo(lang) {
+  langswitchOptions.forEach(o => o.setAttribute('aria-selected','false'));
+  if(lang === 'en') {
+    langswitchEnOption.setAttribute('aria-selected','true');
+    langswitchActiveOption = langswitchEnOption;
+  } else {
+    langswitchPtOption.setAttribute('aria-selected','true');
+    langswitchActiveOption = langswitchPtOption;
+  }
+}
+
+function updateCurrentLabel(lang) {
+  langswitchCurrent.textContent = lang.toUpperCase();
+}
+
+function applyLanguage(lang) {
+  updateCurrentLabel(lang);
+  switchSelectedAttributeTo(lang);
+}
+
+function switchTo(lang) {
+  localStorage.setItem('language', lang);
+  applyLanguage(lang);
+  changePathPrefix(lang);
+}
+
+function changePathPrefix(lang) {
+  var path = window.location.pathname.split('/');
+  if(path[1] === 'en' || path[1] === 'pt') {
+    path[1] = lang;
+  } else {
+    path.splice(1,0,lang);
+  }
+  window.location.pathname = path.join('/');
+}
+
+langswitchButton.addEventListener('click', function() {
+  toggleLangbox();
+  langswitchButton.blur();
+});
+
+langswitchEnOption.addEventListener('click', function(){ switchTo('en'); });
+langswitchPtOption.addEventListener('click', function(){ switchTo('pt'); });
+
+document.addEventListener('mouseup', function(event){
+  if(!langswitchListbox.contains(event.target) && !langswitchButton.contains(event.target)){
+    hideLangbox();
+  }
+});
+
+langswitchOptions.forEach(option => option.addEventListener('mouseenter', function(){
+  removeAllBG();
+  option.classList.add(langswitchBGActive, langswitchBGActiveDark);
+  langswitchActiveOption = option;
+}));
+langswitchListbox.addEventListener('mouseleave', function(){
+  removeAllBG();
+});
+
+langswitchListbox.addEventListener('keydown', function(event){
+  if(event.key === 'Escape') {
+    hideLangbox();
+  } else if(event.key === 'ArrowDown') {
+    event.preventDefault();
+    moveToNextOption();
+  } else if(event.key === 'ArrowUp') {
+    event.preventDefault();
+    moveToPrevOption();
+  } else if(event.shiftKey && event.key == 'Tab') {
+    event.preventDefault();
+    moveToPrevOption();
+  } else if(event.key == 'Tab') {
+    event.preventDefault();
+    moveToNextOption();
+  } else if(event.key === 'Enter') {
+    if(langswitchActiveOption == langswitchEnOption) {
+      switchTo('en');
+    } else {
+      switchTo('pt');
+    }
+  }
+});
+
+function moveToNextOption(){
+  let next = langswitchActiveOption == langswitchEnOption ? langswitchPtOption : langswitchEnOption;
+  removeAllBG();
+  next.classList.add(langswitchBGActive, langswitchBGActiveDark);
+  langswitchActiveOption = next;
+}
+
+function moveToPrevOption(){
+  let prev = langswitchActiveOption == langswitchEnOption ? langswitchPtOption : langswitchEnOption;
+  removeAllBG();
+  prev.classList.add(langswitchBGActive, langswitchBGActiveDark);
+  langswitchActiveOption = prev;
+}
+
+var saved = localStorage.getItem('language');
+if(saved === 'pt') {
+  applyLanguage('pt');
+} else {
+  applyLanguage('en');
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,6 +42,9 @@
     <!-- Dark/light theme switcher script -->
     {{ $themeswitchjs := resources.Get "js/theme-switch.js" }}
     <script defer src="{{ $themeswitchjs.RelPermalink }}"></script>
+    <!-- Language switcher script -->
+    {{ $langswitchjs := resources.Get "js/lang-switch.js" }}
+    <script defer src="{{ $langswitchjs.RelPermalink }}"></script>
     <!-- Hamburger menu switcher script -->
     {{ $hamburgerjs := resources.Get "js/hamburger.js" }}
     <script defer src="{{ $hamburgerjs.RelPermalink }}"></script>

--- a/layouts/partials/lang-switch.html
+++ b/layouts/partials/lang-switch.html
@@ -1,0 +1,28 @@
+<!-- Language switcher dropdown similar to theme switcher -->
+<div id="langswitch-container" class="hidden">
+  <label class="sr-only" id="langswitch-button-label">Language</label>
+  <button
+    id="langswitch-button"
+    type="button"
+    aria-expanded="false"
+    aria-labelledby="langswitch-button-label"
+    aria-haspopup="true"
+    aria-controls="langswitch-options"
+    class="text-gray-500 dark:text-gray-400 focus:outline-none focus:ring-offset-2 focus:ring-2 active:ring-0 focus:border-0 focus:ring-sky-500 ring-offset-blue-50 dark:ring-offset-gray-900 px-1">
+    <span id="langswitch-current" class="uppercase text-sm">EN</span>
+  </button>
+  <ul
+    id="langswitch-options"
+    role="listbox"
+    aria-labelledby="langswitch-button-label"
+    aria-orientation="vertical"
+    tabindex="0"
+    class="hidden absolute overflow-hidden right-0 w-32 flex flex-col bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600 shadow focus:outline-none focus:ring-offset-2 focus:ring-2 focus:border-0 focus:ring-sky-500 ring-offset-blue-50 dark:ring-offset-gray-800">
+    <li id="langswitch-en-option" role="option" tabindex="-1" aria-selected="false" class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">
+      <span class="inline-block font-semibold text-sm text-gray-900 dark:text-gray-100">English</span>
+    </li>
+    <li id="langswitch-pt-option" role="option" tabindex="-1" aria-selected="false" class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">
+      <span class="inline-block font-semibold text-sm text-gray-900 dark:text-gray-100">Português</span>
+    </li>
+  </ul>
+</div>

--- a/layouts/partials/topnav.html
+++ b/layouts/partials/topnav.html
@@ -58,6 +58,9 @@
       <li class="!ml-2 sm:!ml-4">
         {{ partial "theme-switch.html" . }}
       </li>
+      <li class="!ml-2 sm:!ml-4">
+        {{ partial "lang-switch.html" . }}
+      </li>
 
       <!-- Fallback mobile menu when JavaScript is disabled -->
       <noscript>


### PR DESCRIPTION
## Summary
- add `lang-switch.html` partial for picking language
- implement `lang-switch.js` for dropdown behaviour and URL prefix updates
- include the language switcher in the top navigation
- load new script in `baseof.html`

## Testing
- `npm run compile-tailwind` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_6843ac5223408333b490428365f60690