### PR TITLE
Add dynamic translation with API

### DIFF
--- a/assets/js/lang-switch.js
+++ b/assets/js/lang-switch.js
@@ -61,17 +61,9 @@ function applyLanguage(lang) {
 function switchTo(lang) {
   localStorage.setItem('language', lang);
   applyLanguage(lang);
-  changePathPrefix(lang);
-}
-
-function changePathPrefix(lang) {
-  var path = window.location.pathname.split('/');
-  if(path[1] === 'en' || path[1] === 'pt') {
-    path[1] = lang;
-  } else {
-    path.splice(1,0,lang);
+  if (typeof translatePage === 'function') {
+    translatePage(lang);
   }
-  window.location.pathname = path.join('/');
 }
 
 langswitchButton.addEventListener('click', function() {
@@ -138,6 +130,12 @@ function moveToPrevOption(){
 var saved = localStorage.getItem('language');
 if(saved === 'pt') {
   applyLanguage('pt');
+  if (typeof translatePage === 'function') {
+    translatePage('pt');
+  }
 } else {
   applyLanguage('en');
+  if (typeof translatePage === 'function') {
+    translatePage('en');
+  }
 }

--- a/assets/js/translate.js
+++ b/assets/js/translate.js
@@ -1,48 +1,74 @@
-const translator = {
-  lang: 'en',
-  cache: { en: {}, pt: {} },
-  originalText: new Map(),
-  async translateText(text, targetLang) {
-    if(this.cache[targetLang][text]) return this.cache[targetLang][text];
-    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=${targetLang}&dt=t&q=${encodeURIComponent(text)}`;
+const translator = (() => {
+  const cacheKey = lang => `translation-cache-${lang}`;
+  const cache = { en: {}, pt: {} };
+  const originalText = new WeakMap();
+
+  function loadCache(lang) {
     try {
-      const res = await fetch(url);
-      if (!res.ok) return text;
-      const data = await res.json();
-      const translated = data[0].map(part => part[0]).join('');
-      this.cache[targetLang][text] = translated;
-      return translated;
-    } catch (e) {
-      console.error('Translation failed', e);
-      return text;
-    }
-  },
-  getTextNodes(root) {
+      const stored = localStorage.getItem(cacheKey(lang));
+      if (stored) Object.assign(cache[lang], JSON.parse(stored));
+    } catch (_) {}
+  }
+
+  function saveCache(lang) {
+    try {
+      localStorage.setItem(cacheKey(lang), JSON.stringify(cache[lang]));
+    } catch (_) {}
+  }
+
+  async function translateText(text, targetLang) {
+    loadCache(targetLang);
+    if (cache[targetLang][text]) return cache[targetLang][text];
+    const res = await fetch('https://translate.argosopentech.com/translate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: text, source: 'auto', target: targetLang, format: 'text' })
+    });
+    if (!res.ok) return text;
+    const data = await res.json();
+    const translated = data.translatedText;
+    cache[targetLang][text] = translated;
+    saveCache(targetLang);
+    return translated;
+  }
+
+  function getTextNodes(root) {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
       acceptNode(node) {
-        if(!node.parentElement) return NodeFilter.FILTER_REJECT;
+        if (!node.parentElement) return NodeFilter.FILTER_REJECT;
         const tag = node.parentElement.tagName;
-        if(['SCRIPT','STYLE','CODE','PRE'].includes(tag)) return NodeFilter.FILTER_REJECT;
-        if(!node.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
+        if (['SCRIPT', 'STYLE', 'CODE', 'PRE'].includes(tag)) return NodeFilter.FILTER_REJECT;
+        if (!node.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
         return NodeFilter.FILTER_ACCEPT;
       }
     });
     const nodes = [];
     let n;
-    while(n = walker.nextNode()) nodes.push(n);
+    while ((n = walker.nextNode())) nodes.push(n);
     return nodes;
-  },
-  async translatePage(targetLang) {
-    this.lang = targetLang;
-    const nodes = this.getTextNodes(document.body);
+  }
+
+  async function translatePage(targetLang) {
+    if (targetLang === 'en') {
+      for (const [node, text] of originalText) {
+        node.nodeValue = text;
+      }
+      document.documentElement.lang = 'en';
+      return;
+    }
+
+    const nodes = getTextNodes(document.body);
     const promises = nodes.map(async node => {
-      if(!this.originalText.has(node)) this.originalText.set(node, node.nodeValue);
-      const original = this.originalText.get(node);
-      const translated = await this.translateText(original, targetLang);
+      if (!originalText.has(node)) originalText.set(node, node.nodeValue);
+      const original = originalText.get(node);
+      const translated = await translateText(original, targetLang);
       node.nodeValue = translated;
     });
     await Promise.all(promises);
     document.documentElement.lang = targetLang;
   }
-};
+
+  return { translatePage };
+})();
+
 window.translatePage = lang => translator.translatePage(lang);

--- a/assets/js/translate.js
+++ b/assets/js/translate.js
@@ -1,0 +1,48 @@
+const translator = {
+  lang: 'en',
+  cache: { en: {}, pt: {} },
+  originalText: new Map(),
+  async translateText(text, targetLang) {
+    if(this.cache[targetLang][text]) return this.cache[targetLang][text];
+    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=${targetLang}&dt=t&q=${encodeURIComponent(text)}`;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) return text;
+      const data = await res.json();
+      const translated = data[0].map(part => part[0]).join('');
+      this.cache[targetLang][text] = translated;
+      return translated;
+    } catch (e) {
+      console.error('Translation failed', e);
+      return text;
+    }
+  },
+  getTextNodes(root) {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        if(!node.parentElement) return NodeFilter.FILTER_REJECT;
+        const tag = node.parentElement.tagName;
+        if(['SCRIPT','STYLE','CODE','PRE'].includes(tag)) return NodeFilter.FILTER_REJECT;
+        if(!node.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    const nodes = [];
+    let n;
+    while(n = walker.nextNode()) nodes.push(n);
+    return nodes;
+  },
+  async translatePage(targetLang) {
+    this.lang = targetLang;
+    const nodes = this.getTextNodes(document.body);
+    const promises = nodes.map(async node => {
+      if(!this.originalText.has(node)) this.originalText.set(node, node.nodeValue);
+      const original = this.originalText.get(node);
+      const translated = await this.translateText(original, targetLang);
+      node.nodeValue = translated;
+    });
+    await Promise.all(promises);
+    document.documentElement.lang = targetLang;
+  }
+};
+window.translatePage = lang => translator.translatePage(lang);

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -45,6 +45,9 @@
     <!-- Language switcher script -->
     {{ $langswitchjs := resources.Get "js/lang-switch.js" }}
     <script defer src="{{ $langswitchjs.RelPermalink }}"></script>
+    <!-- Page translation script -->
+    {{ $translatejs := resources.Get "js/translate.js" }}
+    <script defer src="{{ $translatejs.RelPermalink }}"></script>
     <!-- Hamburger menu switcher script -->
     {{ $hamburgerjs := resources.Get "js/hamburger.js" }}
     <script defer src="{{ $hamburgerjs.RelPermalink }}"></script>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,12 +42,12 @@
     <!-- Dark/light theme switcher script -->
     {{ $themeswitchjs := resources.Get "js/theme-switch.js" }}
     <script defer src="{{ $themeswitchjs.RelPermalink }}"></script>
-    <!-- Language switcher script -->
-    {{ $langswitchjs := resources.Get "js/lang-switch.js" }}
-    <script defer src="{{ $langswitchjs.RelPermalink }}"></script>
     <!-- Page translation script -->
     {{ $translatejs := resources.Get "js/translate.js" }}
     <script defer src="{{ $translatejs.RelPermalink }}"></script>
+    <!-- Language switcher script -->
+    {{ $langswitchjs := resources.Get "js/lang-switch.js" }}
+    <script defer src="{{ $langswitchjs.RelPermalink }}"></script>
     <!-- Hamburger menu switcher script -->
     {{ $hamburgerjs := resources.Get "js/hamburger.js" }}
     <script defer src="{{ $hamburgerjs.RelPermalink }}"></script>


### PR DESCRIPTION
## Summary
- add translation script that calls Google Translate
- modify language switcher to trigger translation
- include new script in base layout

## Testing
- `npm run compile-tailwind` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_6843af6db63c8333bef112c269adc9f1