### PR TITLE
Fix missing tutorial index content

### DIFF
--- a/content/tutorials/_index.md
+++ b/content/tutorials/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Tutorials"
+date: 2022-12-19
+description: "Collection of step-by-step guides."
+showFooter: true
+---
+
+Welcome! This section brings together various tutorials that walk you through common tasks and concepts.
+
+- [Installing Python](/tutorials/install-python/)
+- [Teoria dos Conjuntos](/tutorials/teoria-conjuntos/)


### PR DESCRIPTION
## Summary
- add front matter and intro text for the Tutorials index page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843b444c23083338b3b698c27e7e723