### PR TITLE
Add alt text support for vim-latex carousel

### DIFF
--- a/data/vim_latex_carousel.yaml
+++ b/data/vim_latex_carousel.yaml
@@ -1,13 +1,19 @@
 images: 
   - image: /vim-latex-carousel/ss.png
     content_html: "1"
+    alt: "Slide 1"
   - image: /vim-latex-carousel/cm.png
     content_html: "2"
+    alt: "Slide 2"
   - image: /vim-latex-carousel/emp.png
     content_html: "3"
+    alt: "Slide 3"
   - image: /vim-latex-carousel/optics.png
     content_html: "4"
+    alt: "Slide 4"
   - image: /vim-latex-carousel/fizmer.png
     content_html: "5"
+    alt: "Slide 5"
   - image: /vim-latex-carousel/qm.png
     content_html: "6"
+    alt: "Slide 6"

--- a/layouts/shortcodes/vim-latex/carousel.html
+++ b/layouts/shortcodes/vim-latex/carousel.html
@@ -9,7 +9,7 @@
   <ul>
     {{ range $index, $slide := .Site.Data.vim_latex_carousel.images }}
     <li id="c{{ $.Scratch.Get "ordinal" }}_slide{{ add $index 1}}" style="min-width: calc(100%/{{ $.Scratch.Get "items" }}); padding-bottom: {{ $.Scratch.Get "height" }}{{ $.Scratch.Get "unit" }};">
-      <img src="{{ $slide.image }}" alt="" />
+      <img src="{{ $slide.image }}" alt="{{ $slide.alt }}" />
     </li>
     {{ end }}
   </ul>


### PR DESCRIPTION
## Summary
- add `alt` fields to each entry in `vim_latex_carousel.yaml`
- expose alt text in `vim-latex` carousel shortcode

## Testing
- `npm run compile-tailwind`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_6843b7444aa48333953c2a953bc94c33